### PR TITLE
Bug Fix for Sanitize Method When The Object Being Sanitized Is Null

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ class Tonic {
   }
 
   static sanitize (o) {
+    if (o === null) return o
     for (const [k, v] of Object.entries(o)) {
       if (typeof v === 'object') o[k] = Tonic.sanitize(v)
       if (typeof v === 'string') o[k] = Tonic.escape(v)


### PR DESCRIPTION
Added a check for when an object is null in the sanitize function, then return it.